### PR TITLE
RHCLOUD-37171: adds the kessel relations-sink package to the connect image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p ${CONNECT_PLUGIN_PATH}
 # Taken from https://github.com/debezium/docker-images/blob/master/connect-base/1.3/docker-maven-download.sh
 COPY docker-maven-download.sh /usr/local/bin/docker-maven-download
 
-RUN MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/postgresql postgresql 42.3.9 69adbbdff317538a33fb72c390b61a7a 
+RUN MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/postgresql postgresql 42.3.9 69adbbdff317538a33fb72c390b61a7a
 
 COPY cyndi-dialect-postgresql.jar $CONNECT_LIB_PATH
 
@@ -31,6 +31,8 @@ RUN MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/op
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-commons 9.5 7d1fce986192f71722b19754e4cb9e61 && \
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-tree 9.5 44755681b7d6fa7143afbb438e55c20c && \
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-util 9.5 ad0016249fb68bb9196babefd47b80dc && \
-    MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-analysis 9.5 4df0adafc78ebba404d4037987d36b61
+    MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-analysis 9.5 4df0adafc78ebba404d4037987d36b61 && \
+    MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/project-kessel kafka-relations-sink 0.4 a4088bb1c7298ac0144056c14fd522ce
+
 
 USER 1001


### PR DESCRIPTION
Changes:
As discussed with @SteveHNH, this PR is to add the Kessel Relations Sink connector to the Insights Kafka Connect image for deploying into FedRAMP. 

Validation:
Since I don't have a good way to test the other connect services, I tested the Relations Sink  with the other Kessel services in ephemeral using an image built with this Dockerfile and build_deploy.sh script and so no major errors or issues. Will test in FedRAMP integration once the image is available for consumption

```shell
# Connect cluster and Connector healthy after deploy
$ oc get kc relations-sink -o jsonpath='{.status.conditions[].status}{"\n"}'
True

$ oc get kctr relations-sink-connector -o jsonpath='{.status.conditions[].status}{"\n"}'
True

$ oc get kc relations-sink -o yaml | grep image:
  image: quay.io/anatale/insights-kafka-connect:2e15110
  
 # Check for errors in log, only found one which I dont believe is an actual error
$ oc logs relations-sink-connect-0 | grep -i error
Jan 23, 2025 3:38:05 PM org.glassfish.jersey.internal.Errors logErrors

$ oc logs relations-sink-connect-0 | grep -i error -A 1 -B 1
WARNING: A provider org.apache.kafka.connect.runtime.rest.resources.LoggingResource registered in SERVER runtime does not implement any provider interfaces applicable in the SERVER runtime. Due to constraint configuration problems the provider org.apache.kafka.connect.runtime.rest.resources.LoggingResource will be ignored. 
Jan 23, 2025 3:38:05 PM org.glassfish.jersey.internal.Errors logErrors
WARNING: The following warnings have been detected: WARNING: The (sub)resource method listLoggers in org.apache.kafka.connect.runtime.rest.resources.LoggingResource contains empty path annotation.
```
