### PR TITLE
RHCLOUD-37171: adds the Kuberentes secret config provider

### DIFF
--- a/deploy/kafka-connect-fedramp.yml
+++ b/deploy/kafka-connect-fedramp.yml
@@ -227,8 +227,9 @@ objects:
       config.storage.topic: ${STORAGE_TOPIC_PREFIX}-connect-offsets
       status.storage.topic: ${STORAGE_TOPIC_PREFIX}-connect-status
       connector.client.config.override.policy: All
-      config.providers: env
+      config.providers: env,secrets
       config.providers.env.class: com.redhat.insights.kafka.config.providers.EnvironmentConfigProvider
+      config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
     externalConfiguration:
       env:
       # advisor


### PR DESCRIPTION
Adds the KuberentesSecretConfigProvider to allow for defining secret values in a Connector instance referencing secret values in a Kuberentes secret. 
This is needed for the relations-sink to configure OIDC information, and is also beneficial to other services with secret configurations

More info: https://strimzi.io/blog/2021/07/22/using-kubernetes-config-provider-to-load-data-from-secrets-and-config-maps/