### PR TITLE
bump base image to support kakfa 39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #This Dockfile is to support the Security-Compliance build of the Xjoin Strimzi Kafka Connect image.
 
-# https://catalog.redhat.com/software/containers/amq-streams/kafka-37-rhel9
-FROM registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0-4.1739284141
+# https://catalog.redhat.com/software/containers/amq-streams/kafka-39-rhel9/67502113e0d4ab9de796ab8d
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-2
 USER root:root
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
Update to a supported base image

## Summary by Sourcery

New Features:
- Upgrade to the latest Red Hat AMQ Streams Kafka base image for Kafka 3.9