### PR TITLE
update kafka base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #This Dockfile is to support the Security-Compliance build of the Xjoin Strimzi Kafka Connect image.
 
 # https://catalog.redhat.com/software/containers/amq-streams/kafka-39-rhel9/67502113e0d4ab9de796ab8d
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-2
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-4
 USER root:root
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Upgrade the base image from version 2.9.0-2 to 2.9.0-4 in the Dockerfile