### PR TITLE
adds debezium postgres connector plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-4
 USER root:root
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \
-    CONNECT_LIB_PATH=/opt/kafka/libs
+    CONNECT_LIB_PATH=/opt/kafka/libs \
+    DEBEZIUM_VERSION=2.7.3.Final
 
 RUN rm -rf /opt/kafka-exporter
 
@@ -32,7 +33,8 @@ RUN MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/op
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-tree 9.5 44755681b7d6fa7143afbb438e55c20c && \
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-util 9.5 ad0016249fb68bb9196babefd47b80dc && \
     MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/ow2/asm asm-analysis 9.5 4df0adafc78ebba404d4037987d36b61 && \
-    MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/project-kessel kafka-relations-sink 0.4 a4088bb1c7298ac0144056c14fd522ce
-
+    MAVEN_DEP_DESTINATION=$CONNECT_LIB_PATH docker-maven-download central org/project-kessel kafka-relations-sink 0.4 a4088bb1c7298ac0144056c14fd522ce && \
+    MAVEN_DEP_DESTINATION=$CONNECT_PLUGIN_PATH docker-maven-download debezium postgres "$DEBEZIUM_VERSION" 9bb46566fa18541be206f0bd0f77c4de && \
+    MAVEN_DEP_DESTINATION=$CONNECT_PLUGIN_PATH docker-maven-download debezium-optional scripting "$DEBEZIUM_VERSION" e8c6825ada56c4f028b67fe634f7d4d6
 
 USER 1001


### PR DESCRIPTION
Changes:
* Adds debezium connector and debezium scripting to Connect image

Reason:
* Kessel Inventory, when live in FedRAMP, will require Debezium for handling requests
* The Insights Inventory team is migrating away from using the `xjoin-kafka-connect` image as the default connect image used in Ephemeral, and plans to replace it with this image. This change ensures Debezium is still available in ephemeral after this migration
* The Debezium version used is also the same used by [Platform MQ](https://github.com/RedHatInsights/platform-mq/blob/master/Connect/Dockerfile#L27) to try and avoid using different versions in FedRAMP and Commercial for services requiring Debezium

Validation:
The Kessel Inventory ephemeral setup currently stands up its own Kafka and Kafka Connect cluster for testing. I was able to build the image and push to a personal quay and use this connect image for the Connect cluster with no issues

```shell
# connect pod is healthy
$ oc get pod inventory-kafka-connect-connect-0
NAME                                READY   STATUS    RESTARTS   AGE
inventory-kafka-connect-connect-0   1/1     Running   0          11m

# Connect cluster using new image i built, and includes debezium plugin as expected
$ oc get kc inventory-kafka-connect -o yaml | grep -E "image:|debezium"
  image: quay.io/anatale/insights-kafka-connect:4d3f0c4
  - class: io.debezium.connector.postgresql.PostgresConnector

# connector that requires debezium connector is Ready  
$ oc get kctr kessel-inventory-source-connector 
NAME                                CLUSTER                   CONNECTOR CLASS                                      MAX TASKS   READY
kessel-inventory-source-connector   inventory-kafka-connect   io.debezium.connector.postgresql.PostgresConnector   1           True
```

## Summary by Sourcery

Add Debezium PostgreSQL connector and scripting plugin to the Kafka Connect image for Kessel Inventory's requirements

New Features:
- Integrate Debezium PostgreSQL connector plugin version 2.7.3.Final into the Kafka Connect image

Deployment:
- Configure Debezium plugin installation path in the Dockerfile
- Set Debezium version as an environment variable

Chores:
- Update Dockerfile to download and include Debezium PostgreSQL connector and scripting plugins