### PR TITLE
Add security workflow

### DIFF
--- a/.github/workflows/security-workflow-template.yml
+++ b/.github/workflows/security-workflow-template.yml
@@ -1,0 +1,12 @@
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -33,7 +33,7 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 
 if [[ "$GIT_BRANCH" != "origin/security-compliance" ]]; then
-    DOCKER_FILE="Dockerfile-strimzi"
+    DOCKER_FILE="Dockerfile"
     docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" -f "$PWD/$DOCKER_FILE" "$PWD"
     docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
     docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"


### PR DESCRIPTION
## Summary by Sourcery

Add a security scanning workflow to the repository for automated security checks on specified branches

Build:
- Modify build script to use default Dockerfile instead of Dockerfile-strimzi

CI:
- Introduce a GitHub Actions workflow that runs security scans on main, master, and security-compliance branches