### PR TITLE
task: add security workflow to scan images

### DIFF
--- a/.github/workflows/security-workflow.yml
+++ b/.github/workflows/security-workflow.yml
@@ -1,0 +1,27 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #This Dockfile is to support the Security-Compliance build of the Xjoin Strimzi Kafka Connect image.
 
 # https://catalog.redhat.com/software/containers/amq-streams/kafka-39-rhel9/67502113e0d4ab9de796ab8d
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-2
+FROM registry.access.redhat.com/amq-streams/kafka-39-rhel9:2.9.0-2
 USER root:root
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
Add the security workflow to this repo so we can scan the images before merges

## Summary by Sourcery

Add a security workflow to scan container images using Anchore's Grype and Syft tools for vulnerability detection and SBOM generation

CI:
- Implement a GitHub Actions workflow to perform security scans on container images for main, master, and security-compliance branches

Chores:
- Update Dockerfile base image registry from registry.redhat.io to registry.access.redhat.com